### PR TITLE
chore(jenkins) make the jenkins docker image configurable

### DIFF
--- a/master.yaml
+++ b/master.yaml
@@ -20,6 +20,10 @@ Parameters:
         Description: Which instance type should we use to build the ECS cluster?
         Type: String
         Default: t2.medium
+    JenkinsImage:
+        Description: The Jenkins docker image tag we want to run
+        Type: String
+        Default: mashape/jenkins:latest
 
 Resources:
 
@@ -83,6 +87,7 @@ Resources:
         Properties:
             TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/services/jenkins-service/service.yaml
             Parameters:
+                JenkinsImage: !Ref JenkinsImage
                 VPC: !GetAtt VPC.Outputs.VPC
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 Listener: !GetAtt ALB.Outputs.Listener 

--- a/services/jenkins-service/service.yaml
+++ b/services/jenkins-service/service.yaml
@@ -25,6 +25,11 @@ Parameters:
         Type: String
         Default: '*'
 
+    JenkinsImage:
+        Description: The Jenkins docker image tag we want to run
+        Type: String
+        Default: mashape/jenkins:latest
+
 Resources:
 
     Service: 
@@ -59,7 +64,7 @@ Resources:
                       - SourceVolume: jenkins_home
                         ContainerPath: /var/jenkins_home
                   Essential: true
-                  Image: mashape/jenkins:latest
+                  Image: !Ref JenkinsImage
                   Cpu: 1024
                   MemoryReservation: 2048
                   PortMappings:


### PR DESCRIPTION
- spin up cloudformation using the configuration currently on master
- login to jenkins (ignore the bad ssl certificate)
- have jenkins install the default plugins
- wait for aws to cycle jenkins
- upgrade via the cloudformation at the head of this branch
- wait for aws to cycle jenkins (noop)
- update jenkins set the image to a tag
- wait for aws to cycle