### PR TITLE
feat: ec2 iam instance role

### DIFF
--- a/infrastructure/ecs-cluster.yaml
+++ b/infrastructure/ecs-cluster.yaml
@@ -346,60 +346,45 @@ Resources:
                         }
                     }]
                 }
+            ManagedPolicyArns:
+                - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+                - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+                - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
             Policies:
-                - PolicyName: ecs-service
+                - PolicyName: jenkins-service
                   PolicyDocument: |
                     {
                         "Statement": [{
                             "Effect": "Allow",
                             "Action": [
-                                "ecs:CreateCluster",
-                                "ecs:DeregisterContainerInstance",
-                                "ecs:DiscoverPollEndpoint",
-                                "ecs:Poll",
-                                "ecs:RegisterContainerInstance",
-                                "ecs:StartTelemetrySession",
-                                "ecs:Submit*",
-                                "logs:CreateLogStream",
-                                "logs:PutLogEvents",
-                                "ecr:BatchCheckLayerAvailability",
-                                "ecr:BatchGetImage",
-                                "ecr:GetDownloadUrlForLayer",
-                                "ecr:GetAuthorizationToken",
-                                "ssm:DescribeAssociation",
-                                "ssm:GetDeployablePatchSnapshotForInstance",
-                                "ssm:GetDocument",
-                                "ssm:GetManifest",
-                                "ssm:GetParameters",
-                                "ssm:ListAssociations",
-                                "ssm:ListInstanceAssociations",
-                                "ssm:PutInventory",
-                                "ssm:PutComplianceItems",
-                                "ssm:PutConfigurePackageResult",
-                                "ssm:UpdateAssociationStatus",
-                                "ssm:UpdateInstanceAssociationStatus",
-                                "ssm:UpdateInstanceInformation",
-                                "ec2messages:AcknowledgeMessage",
-                                "ec2messages:DeleteMessage",
-                                "ec2messages:FailMessage",
-                                "ec2messages:GetEndpoint",
-                                "ec2messages:GetMessages",
-                                "ec2messages:SendReply",
-                                "cloudwatch:PutMetricData",
-                                "ec2:DescribeInstanceStatus",
-                                "ds:CreateComputer",
-                                "ds:DescribeDirectories",
-                                "logs:CreateLogGroup",
-                                "logs:CreateLogStream",
-                                "logs:DescribeLogGroups",
-                                "logs:DescribeLogStreams",
-                                "logs:PutLogEvents",
-                                "s3:PutObject",
-                                "s3:GetObject",
-                                "s3:AbortMultipartUpload",
-                                "s3:ListMultipartUploadParts",
-                                "s3:ListBucket",
-                                "s3:ListBucketMultipartUploads"
+                                "ec2:CopyImage",
+                                "ec2:CreateImage",
+                                "ec2:RebootInstances",
+                                "ec2:TerminateInstances",
+                                "ec2:StopInstances"
+                            ],
+                            "Resource": "arn:aws:ec2:us-east-1:151743893450:instance/*",
+                            "Condition": {
+                                "StringEquals": {
+                                    "ec2:ResourceTag/Name": "Packer Builder"
+                                }
+                            }
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [
+                                "ec2:AuthorizeSecurityGroupIngress",
+                                "ec2:Describe*",
+                                "ec2:ImportKeyPair",
+                                "ec2:CreateKeyPair",
+                                "ec2:CreateSecurityGroup",
+                                "ec2:CreateTags",
+                                "ec2:RunInstances",
+                                "ec2:DeleteKeyPair",
+                                "ec2:CopyImage",
+                                "ec2:CreateImage",
+                                "ec2:DeregisterImage",
+                                "ec2:DeleteSnapshot"
                             ],
                             "Resource": "*"
                         }]

--- a/master.yaml
+++ b/master.yaml
@@ -82,6 +82,7 @@ Resources:
         Properties:
             TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/services/jenkins-service/service.yaml
             Parameters:
+                EnvironmentName: !Ref AWS::StackName
                 JenkinsImage: !Ref JenkinsImage
                 VPC: !GetAtt VPC.Outputs.VPC
                 Cluster: !GetAtt ECS.Outputs.Cluster

--- a/master.yaml
+++ b/master.yaml
@@ -26,7 +26,7 @@ Resources:
     VPC:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/infrastructure/vpc.yaml
+            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/infrastructure/vpc.yaml
             Parameters:
                 EnvironmentName:    !Ref AWS::StackName
                 VpcCIDR:            10.180.0.0/16
@@ -38,7 +38,7 @@ Resources:
     SecurityGroups:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/infrastructure/security-groups.yaml
+            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/infrastructure/security-groups.yaml
             Parameters: 
                 EnvironmentName: !Ref AWS::StackName
                 VPC: !GetAtt VPC.Outputs.VPC
@@ -47,7 +47,7 @@ Resources:
     ALB:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/infrastructure/load-balancers.yaml
+            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/infrastructure/load-balancers.yaml
             Parameters:
                 EnvironmentName: !Ref AWS::StackName
                 VPC: !GetAtt VPC.Outputs.VPC
@@ -57,7 +57,7 @@ Resources:
     ECS:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/infrastructure/ecs-cluster.yaml
+            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/infrastructure/ecs-cluster.yaml
             Parameters:
                 ClusterSize: !Ref ClusterSize
                 InstanceType: !Ref InstanceType
@@ -72,7 +72,7 @@ Resources:
     LifecycleHook:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/infrastructure/lifecyclehook.yaml
+            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/infrastructure/lifecyclehook.yaml
             Parameters:
                 Cluster: !GetAtt ECS.Outputs.Cluster
                 ECSAutoScalingGroupName: !GetAtt ECS.Outputs.ECSAutoScalingGroupName
@@ -80,7 +80,7 @@ Resources:
     JenkinsService:
         Type: AWS::CloudFormation::Stack
         Properties:
-            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins/services/jenkins-service/service.yaml
+            TemplateURL: https://s3.amazonaws.com/aws-ecs-jenkins-test/services/jenkins-service/service.yaml
             Parameters:
                 JenkinsImage: !Ref JenkinsImage
                 VPC: !GetAtt VPC.Outputs.VPC

--- a/services/jenkins-service/service.yaml
+++ b/services/jenkins-service/service.yaml
@@ -3,6 +3,10 @@ Description: >
 
 Parameters: 
 
+    EnvironmentName:
+        Description: An environment name that will be prefixed to resource names
+        Type: String
+        
     VPC:
         Description: The VPC that the ECS cluster is deployed to
         Type: AWS::EC2::VPC::Id
@@ -45,21 +49,21 @@ Resources:
               - Type: spread
                 Field: host
             LoadBalancers: 
-                - ContainerName: "jenkins-service"
+                - ContainerName: !Sub ${EnvironmentName}-jenkins
                   ContainerPort: 8080
                   TargetGroupArn: !Ref TargetGroup
 
     TaskDefinition:
         Type: AWS::ECS::TaskDefinition
         Properties:
-            Family: jenkins-service
+            Family: !Sub ${EnvironmentName}-jenkins
             Volumes:
                 -
                   Host:
                       SourcePath: /var/jenkins_home
                   Name: jenkins_home
             ContainerDefinitions:
-                - Name: jenkins-service
+                - Name: !Sub ${EnvironmentName}-jenkins
                   MountPoints:
                       - SourceVolume: jenkins_home
                         ContainerPath: /var/jenkins_home


### PR DESCRIPTION
make it so jenkins doesn't require aws credentials and can instead use the ec2 instance profile role